### PR TITLE
feat(quickstart): add step for minio config

### DIFF
--- a/src/quickstart.mdx
+++ b/src/quickstart.mdx
@@ -35,6 +35,14 @@ production:
   #api_url: "https://api.cypress.io/"
 ```
 
+## Configure the storage driver
+
+Edit your /etc/hosts file to allow cypress agents discover the local instance of [Minio Driver](/director/storage#minio-driver)
+
+```sh
+127.0.0.1 storage
+```
+
 ## Run cypress tests in parallel
 
 1. Open few terminals


### PR DESCRIPTION
This simply adds a step for storage driver config to allow image and video upload in the quickstart. 
Solves this [issue](https://github.com/sorry-cypress/sorry-cypress/issues/208) and prevents other people to run into the same problem.