### PR TITLE
Try and steer users towards the helm chart

### DIFF
--- a/src/installation/kubernetes.mdx
+++ b/src/installation/kubernetes.mdx
@@ -4,4 +4,10 @@ route: /installation/kubernetes
 menu: Installation
 ---
 
-- [_Playing With Sorry Cypress And Kubernetes_](https://crumbhole.com/playing-with-sorry-cypress-and-kubernetes/) by Tim Collins
+There is a Helm chart for Sorry Cypress. Detailed information on the latest release versions plus how to install and configure can be found at [Artifact Hub](https://artifacthub.io/packages/helm/sorry-cypress/sorry-cypress).
+
+The chart is designed to work with Kubernetes 1.16 to 1.20.
+
+If you find any issues with the Helm chart, or you wish to raise a feature request, please raise an issue in the [Sorry Cypress Charts Git repository](https://github.com/sorry-cypress/charts/issues)
+
+- [_Introducing the Sorry Cypress Helm Chart_](https://crumbhole.com/indroducing-the-sorry-cypress-helm-chart/) by Tim Collins


### PR DESCRIPTION
The Helm chart is now arguably the preferred way we would like Kubernetes users to use Sorry Cypress, so this just adds a few lines to the documentation to steer users that way.

With the chart having multiple releases daily, I didn't think it was wise to directly put the readme into the documentation. Instead, I'm pointing users at ArtifactHub, which pulls the readme on each release.